### PR TITLE
Add eza to Brewfile for ls alias support

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -17,6 +17,7 @@ brew "bat"          # cat replacement
 brew "ripgrep"      # grep replacement
 brew "fd"           # find replacement
 brew "jq"           # JSON processor
+brew "eza"          # ls replacement
 
 # Development Applications
 cask "visual-studio-code"


### PR DESCRIPTION
- Add eza package to Command Line Utilities section
- Fixes fish shell error when ls command tries to use eza
- Resolves issue where eza was referenced but not installed

Addresses #16
