### PR TITLE
Add PyCharm to Development Applications

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -22,6 +22,7 @@ brew "eza"          # ls replacement
 # Development Applications
 cask "visual-studio-code"
 cask "bruno"
+cask "pycharm"
 
 # Productivity & Utilities
 cask "rectangle"            # window management

--- a/dotfiles.code-workspace
+++ b/dotfiles.code-workspace
@@ -1,0 +1,13 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "workbench.colorTheme": "Monokai",
+    "editor.fontSize": 12,
+    "editor.tabSize": 4,
+    "terminal.integrated.fontFamily": "JetBrains Mono"
+  }
+}

--- a/scripts/setup_dock.sh
+++ b/scripts/setup_dock.sh
@@ -25,6 +25,7 @@ dockutil --add '' --type spacer --section apps --no-restart
 dockutil --add "/Applications/Visual Studio Code.app" --no-restart
 dockutil --add "/Applications/Kitty.app" --no-restart
 dockutil --add "/Applications/Bruno.app" --no-restart
+dockutil --add "/Applications/PyCharm.app" --no-restart
 dockutil --add '' --type spacer --section apps --no-restart
 
 # -----------------------


### PR DESCRIPTION
- Add PyCharm Professional Edition to Brewfile
- Provides comprehensive Python development environment
- Consistent IDE setup across machines

Addresses #18