### PR TITLE
Add AWS CLI to development tools

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,6 +10,7 @@ brew "node"
 brew "pipx"
 brew "dockutil"
 brew "uv"
+brew "awscli"
 
 # Command Line Utilities
 brew "zoxide"       # cd replacement


### PR DESCRIPTION
- Added awscli to Brewfile under Core Development Tools section
- Enables AWS command-line operations for development environment
- Addresses issue #24

🤖 Generated with [Claude Code](https://claude.ai/code)