### PR TITLE
Add google-cloud-sdk and databricks CLI to development tools

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -11,6 +11,8 @@ brew "pipx"
 brew "dockutil"
 brew "uv"
 brew "awscli"
+brew "google-cloud-sdk"
+brew "databricks"
 
 # Command Line Utilities
 brew "zoxide"       # cd replacement


### PR DESCRIPTION
## Summary
- Added google-cloud-sdk for Google Cloud Platform command-line tools
- Added databricks CLI for Databricks platform integration
- Both tools are integrated into the existing Brewfile for automatic installation

## Changes Made
- Updated `Brewfile` to include `google-cloud-sdk` and `databricks` packages
- Tools will be automatically installed when running the bootstrap script

## Test Plan
- [ ] Verify tools install correctly with `brew bundle`
- [ ] Confirm google-cloud-sdk is accessible via `gcloud` command
- [ ] Confirm databricks CLI is accessible via `databricks` command

Closes #26

🤖 Generated with [Claude Code](https://claude.ai/code)