### PR TITLE
Add draw.io desktop app to development tools

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -31,6 +31,7 @@ brew "eza"          # ls replacement
 # Development Applications
 cask "bruno"
 cask "cursor"
+cask "drawio"
 cask "lens"
 cask "pycharm"
 cask "visual-studio-code"

--- a/scripts/setup_dock.sh
+++ b/scripts/setup_dock.sh
@@ -24,6 +24,7 @@ dockutil --add '' --type spacer --section apps --no-restart
 # -----------------------
 dockutil --add "/Applications/Bruno.app" --no-restart
 dockutil --add "/Applications/Cursor.app" --no-restart
+dockutil --add "/Applications/draw.io.app" --no-restart
 dockutil --add "/Applications/Kitty.app" --no-restart
 dockutil --add "/Applications/PyCharm.app" --no-restart
 dockutil --add "/Applications/Visual Studio Code.app" --no-restart


### PR DESCRIPTION
## Summary
- Added draw.io to the Development Applications section in Brewfile
- Added draw.io to the Dev & Ops section in dock setup script
- Provides desktop application for creating diagrams, flowcharts, and technical documentation

## Test plan
- [ ] Run `brew bundle` to verify draw.io installs correctly
- [ ] Launch draw.io to confirm it works properly
- [ ] Run dock setup script to verify draw.io appears in dock

🤖 Generated with [Claude Code](https://claude.ai/code)