### PR TITLE
Add JetBrains DataGrip to development tools

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -27,10 +27,12 @@ brew "ripgrep"      # grep replacement
 brew "fd"           # find replacement
 brew "jq"           # JSON processor
 brew "eza"          # ls replacement
+brew "duckdb"       # analytical SQL database
 
 # Development Applications
 cask "bruno"
 cask "cursor"
+cask "datagrip"
 cask "drawio"
 cask "lens"
 cask "pycharm"

--- a/Brewfile
+++ b/Brewfile
@@ -31,6 +31,7 @@ brew "eza"          # ls replacement
 # Development Applications
 cask "bruno"
 cask "cursor"
+cask "drawio"
 cask "lens"
 cask "pycharm"
 cask "visual-studio-code"

--- a/scripts/setup_dock.sh
+++ b/scripts/setup_dock.sh
@@ -24,6 +24,7 @@ dockutil --add '' --type spacer --section apps --no-restart
 # -----------------------
 dockutil --add "/Applications/Bruno.app" --no-restart
 dockutil --add "/Applications/Cursor.app" --no-restart
+dockutil --add "/Applications/DataGrip.app" --no-restart
 dockutil --add "/Applications/draw.io.app" --no-restart
 dockutil --add "/Applications/Kitty.app" --no-restart
 dockutil --add "/Applications/PyCharm.app" --no-restart

--- a/scripts/setup_dock.sh
+++ b/scripts/setup_dock.sh
@@ -24,6 +24,7 @@ dockutil --add '' --type spacer --section apps --no-restart
 # -----------------------
 dockutil --add "/Applications/Bruno.app" --no-restart
 dockutil --add "/Applications/Cursor.app" --no-restart
+dockutil --add "/Applications/draw.io.app" --no-restart
 dockutil --add "/Applications/Kitty.app" --no-restart
 dockutil --add "/Applications/PyCharm.app" --no-restart
 dockutil --add "/Applications/Visual Studio Code.app" --no-restart


### PR DESCRIPTION
## Summary
- Added JetBrains DataGrip to the Development Applications section in Brewfile
- Added DataGrip to the Dev & Ops section in dock setup script
- Provides comprehensive database IDE for SQL development, database management, and data analysis

## Test plan
- [ ] Run `brew bundle` to verify DataGrip installs correctly
- [ ] Launch DataGrip to confirm it works properly
- [ ] Run dock setup script to verify DataGrip appears in dock

🤖 Generated with [Claude Code](https://claude.ai/code)