### PR TITLE
Add btop, cmatrix, glow, qpdf CLI utilities

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -28,10 +28,14 @@ cask "google-cloud-sdk"
 
 # Command Line Utilities
 brew "bat"          # cat replacement
+brew "btop"         # resource monitor
+brew "cmatrix"      # terminal matrix animation
 brew "eza"          # ls replacement
 brew "fd"           # find replacement
 brew "fzf"          # fuzzy finder
+brew "glow"         # markdown renderer
 brew "jq"           # JSON processor
+brew "qpdf"         # PDF transform & inspect
 brew "ripgrep"      # grep replacement
 brew "tree"         # directory tree display
 brew "zoxide"       # cd replacement


### PR DESCRIPTION
Adds CLI tools installed on the Mac but missing from the Brewfile: `btop`, `cmatrix`, `glow`, `qpdf`.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_