### PR TITLE
Add MS SQL Server ODBC support

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 # Taps
 tap "databricks/tap"
+tap "microsoft/mssql-release", "https://github.com/Microsoft/homebrew-mssql-release"
 
 # Shell & Terminal
 brew "fish"
@@ -61,6 +62,10 @@ cask "chatgpt"
 cask "chatgpt-atlas"
 cask "claude"
 brew "codex"
+
+# Database Drivers
+brew "unixodbc"                                              # ODBC 3 connectivity for UNIX
+brew "microsoft/mssql-release/msodbcsql18", trusted: true   # MS SQL Server ODBC driver
 
 # Document Processing
 brew "pandoc"


### PR DESCRIPTION
Tracks the Microsoft SQL Server ODBC driver stack: `microsoft/mssql-release` tap, `unixodbc`, and `msodbcsql18`.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_