### PR TITLE
Update renamed Homebrew casks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,7 +9,7 @@ cask "kitty"
 # Core Development Tools
 brew "act"
 brew "awscli"
-cask "docker"
+cask "docker-desktop"
 brew "dockutil"
 brew "duckdb"
 brew "gh"
@@ -22,7 +22,7 @@ brew "postgresql@14"
 brew "terraform"
 brew "terragrunt"
 brew "uv"
-cask "google-cloud-sdk"
+cask "gcloud-cli"
 
 # Command Line Utilities
 brew "bat"          # cat replacement


### PR DESCRIPTION
Updates casks to their current Homebrew names: `docker` → `docker-desktop`, `google-cloud-sdk` → `gcloud-cli`.

(`kubectl` is not renamed here — it is removed in #71.)

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_