### PR TITLE
Remove unused Kubernetes, Databricks, and DataGrip tooling

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,4 @@
 # Taps
-tap "databricks/tap"
 tap "microsoft/mssql-release", "https://github.com/Microsoft/homebrew-mssql-release"
 
 # Shell & Terminal
@@ -16,7 +15,6 @@ brew "duckdb"
 brew "gh"
 brew "git"
 brew "git-filter-repo"
-brew "kubectl"
 brew "node"
 brew "pipx"
 brew "postgresql@14"
@@ -41,9 +39,7 @@ brew "zoxide"       # cd replacement
 
 # Development Applications
 cask "cursor"
-cask "datagrip"
 cask "fork"
-cask "lens"
 cask "pycharm"
 cask "visual-studio-code"
 


### PR DESCRIPTION
Removes tooling no longer used in any environment: `kubectl`, `lens` (Kubernetes IDE), `datagrip`, and the `databricks/tap`.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_