### PR TITLE
Remove Bruno from Dock setup

### DIFF
--- a/scripts/setup_dock.sh
+++ b/scripts/setup_dock.sh
@@ -28,7 +28,6 @@ dockutil --add '' --type spacer --section apps --no-restart
 # -----------------------
 # 👨‍💻 Dev & Ops
 # -----------------------
-dockutil --add "/Applications/Bruno.app" --no-restart
 dockutil --add "/Applications/Cursor.app" --no-restart
 dockutil --add "/Applications/Fork.app" --no-restart
 dockutil --add "/Applications/Kitty.app" --no-restart


### PR DESCRIPTION
`setup_dock.sh` still pinned `Bruno.app` to the Dock, but `bruno` was removed from the Brewfile in #67. On a fresh machine Bruno won't be installed, so drop the Dock entry to keep the setup consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_