### PR TITLE
Set Ghostty default font-size to 10

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -3,7 +3,7 @@
 
 # --- Font ---
 font-family = JetBrainsMono Nerd Font
-font-size = 13
+font-size = 10
 
 # --- Window / macOS ---
 macos-option-as-alt = true


### PR DESCRIPTION
Reduces the Ghostty default `font-size` from 13 to 10 (points).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_