### PR TITLE
Harden bootstrap: safe symlinks + Swift/CLT preflight

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,8 +3,34 @@ set -e
 
 echo "🚀 Bootstrapping your dev environment..."
 
+# Safely (re)create a symlink at $2 pointing to $1, replacing any existing
+# file/dir/symlink so we never nest a link inside an existing directory.
+link_config() {
+  local src="$1" dest="$2"
+  if [[ -L "$dest" && "$(readlink "$dest")" == "$src" ]]; then
+    echo "  ✓ $dest already linked"
+    return
+  fi
+  if [[ -e "$dest" || -L "$dest" ]]; then
+    echo "  ↻ replacing existing $dest"
+    rm -rf "$dest"
+  fi
+  ln -s "$src" "$dest"
+  echo "  → linked $dest"
+}
+
+# Warn early if the Swift/Command Line Tools toolchain is broken — otherwise
+# Homebrew casks that move .app bundles fail cryptically mid-run.
+check_swift_toolchain() {
+  if ! printf 'print("ok")\n' | swift - >/dev/null 2>&1; then
+    echo "⚠️  Swift / Command Line Tools look broken — casks that move .app bundles may fail."
+    echo "    Fix: sudo rm -rf /Library/Developer/CommandLineTools && sudo xcode-select --install"
+  fi
+}
+
 OS="$(uname -s)"
 if [[ "$OS" == "Darwin" ]]; then
+  check_swift_toolchain
   ./scripts/install_brew.sh
 elif [[ "$OS" == "Linux" ]]; then
   ./scripts/install_apt.sh || echo "Skip (not implemented)"
@@ -38,8 +64,8 @@ fi
 
 echo "🔗 Symlinking configs..."
 mkdir -p ~/.config
-ln -sf "$PWD/.config/ghostty" ~/.config/ghostty
-ln -sf "$PWD/.config/starship.toml" ~/.config/starship.toml
-ln -sf "$PWD/.config/fish" ~/.config/fish
+link_config "$PWD/.config/ghostty" ~/.config/ghostty
+link_config "$PWD/.config/starship.toml" ~/.config/starship.toml
+link_config "$PWD/.config/fish" ~/.config/fish
 
 echo "✅ Dotfiles setup complete!"


### PR DESCRIPTION
Two reliability fixes for `bootstrap.sh`:

**Safe symlink relinking** — a new `link_config()` helper removes any existing file/dir/symlink at the destination before creating the link. This prevents the "nested symlink inside an existing dir" bug (hit when Ghostty had already created `~/.config/ghostty`), and makes re-runs idempotent.

**Swift/CLT preflight** — `check_swift_toolchain()` warns up front if the Command Line Tools are broken (the `SwiftBridging`/SDK mismatch that made Rectangle & ChatGPT cask upgrades fail), instead of failing cryptically mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_