### PR TITLE
Remove wrong cask "shadow" (Shadow PC, not the notetaker)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -47,7 +47,6 @@ cask "visual-studio-code"
 cask "rectangle"            # window management
 cask "obsidian"            # note taking
 cask "beyond-compare"       # file comparison and management
-cask "shadow"               # cloud gaming / remote desktop
 
 # Browsers
 cask "google-chrome"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -70,7 +70,7 @@ The Brewfile is the heart of the setup — `brew bundle` installs everything in 
 | **Core Dev** | act, awscli, docker-desktop, dockutil, duckdb, gh, git, git-filter-repo, node, pipx, postgresql@14, terraform, terragrunt, uv, gcloud-cli |
 | **CLI Utilities** | bat, btop, cmatrix, eza, fd, fzf, glow, jq, qpdf, ripgrep, tree, zoxide |
 | **Dev Apps** | cursor, fork, pycharm, visual-studio-code |
-| **Productivity** | rectangle, obsidian, beyond-compare, shadow |
+| **Productivity** | rectangle, obsidian, beyond-compare |
 | **Browsers** | google-chrome, microsoft-edge |
 | **AI Tools** | chatgpt, claude, codex |
 | **DB Drivers** | unixodbc, msodbcsql18 (MS SQL ODBC) |
@@ -78,9 +78,6 @@ The Brewfile is the heart of the setup — `brew bundle` installs everything in 
 | **Fonts** | font-jetbrains-mono-nerd-font |
 | **VS Code** | 17 extensions (Python, Jupyter, Terraform, YAML, PlantUML, Mermaid, Atlassian, Monokai Pro, Makefile…) |
 | **npm globals** | @anthropic-ai/claude-code, @mermaid-js/mermaid-cli |
-
-> **Tracked but installed outside brew:** `shadow` is kept in the Brewfile even though it
-> doesn't appear in `brew bundle dump` — it's managed another way but I want it tracked.
 
 **Keeping the Brewfile in sync with the Mac:**
 


### PR DESCRIPTION
Removes `cask "shadow"` from the Brewfile. That cask is **Shadow PC** (cloud gaming / remote desktop, shadow.tech) — not the non-joining AI meeting transcriber that was actually wanted. Also drops the now-obsolete "tracked outside brew" note and the Productivity table entry in `docs/setup.md`.

A transcription app (e.g. a `mas` entry for Just Press Record) can be added separately once a pick is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_