### PR TITLE
Add CI (shellcheck + Brewfile validation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  shellcheck:
+    name: ShellCheck scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        run: shellcheck --severity=error scripts/*.sh
+
+  brewfile:
+    name: Validate Brewfile
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse Brewfile
+        run: brew bundle list --file=Brewfile >/dev/null

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # jitsejan/dotfiles
 
+![CI](https://github.com/jitsejan/dotfiles/actions/workflows/ci.yml/badge.svg)
+
 Personal terminal setup using:
 - 👻 Ghostty terminal
-- 🚀 Starship prompt with Git + Python (Rye + uv)
+- 🚀 Starship prompt with Git + Python (uv)
 - 🍺 Brewfile for reproducible packages
-- 🐍 Python tools like ruff, black, isort, pyright
+- 🐍 Python tools like ruff and pyright
 
 ## 📦 Setup
 
@@ -12,3 +14,7 @@ Personal terminal setup using:
 git clone git@github.com:jitsejan/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 ./scripts/bootstrap.sh
+```
+
+See [`docs/setup.md`](docs/setup.md) for a full breakdown of the repo, the
+approach, and how the machine is provisioned.


### PR DESCRIPTION
Adds a lightweight CI workflow and refreshes the README.

**`.github/workflows/ci.yml`** (runs on push to master + PRs):
- **ShellCheck** — lints `scripts/*.sh` on Ubuntu (`--severity=error`).
- **Validate Brewfile** — parses the Brewfile on macOS via `brew bundle list` to catch syntax errors before you run it on a real machine.

**README** — adds a CI badge, fixes the previously unclosed code fence, drops the stale Rye/black/isort mentions (superseded by the uv + ruff modernization), and links to `docs/setup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbSPJ8X9Zi6VUk7Dq39hi)_