### PR TITLE
Fix codex to use cask instead of formula

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -55,7 +55,7 @@ cask "microsoft-edge"
 # AI Tools
 cask "chatgpt"
 cask "claude"
-brew "codex"
+cask "codex"
 
 # Database Drivers
 brew "unixodbc"                                              # ODBC 3 connectivity for UNIX


### PR DESCRIPTION
## Summary
- `brew "codex"` was migrated from homebrew/core to homebrew/cask, causing `brew bundle` to fail
- Changed to `cask "codex"` to fix installation

## Test plan
- [ ] Run `brew bundle` and confirm codex installs without errors