### PR TITLE
Clean up bootstrap scripts

### DIFF
--- a/scripts/install_apps.sh
+++ b/scripts/install_apps.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-# Claude Code
-npm install -g @anthropic-ai/claude-code
-
-# Mermaid CLI
-npm install -g @mermaid-js/mermaid-cli
+# Claude Code and Mermaid CLI are installed via Brewfile npm entries — nothing to do here.

--- a/scripts/install_python_tools.sh
+++ b/scripts/install_python_tools.sh
@@ -3,11 +3,7 @@ set -e
 
 echo "🐍 Installing Python tools..."
 
-# Install uv (package installer, resolver, and project/Python-version manager;
-# also replaces Rye, which is now maintenance-only).
-if ! command -v uv &>/dev/null; then
-  curl -sSf https://astral.sh/uv/install.sh | sh
-fi
+# uv is installed via Brewfile — nothing to do here.
 
 # Python dev tools via pipx.
 # ruff covers linting + formatting + import sorting (replaces black & isort).

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -11,14 +11,8 @@ fi
 
 echo "✅ Codex CLI found: $(codex --version)"
 
-# Check if already authenticated
-if codex login --check &>/dev/null; then
-  echo "✅ Codex is already authenticated"
-else
-  echo "🔐 Setting up Codex authentication..."
-  echo "Please follow the authentication process:"
-  codex login || true
-fi
+# Skip auth — requires an interactive browser session; run 'codex login' manually after setup.
+echo "ℹ️  Skipping Codex auth — run 'codex login' manually to authenticate"
 
 # Create basic config directory if it doesn't exist
 mkdir -p ~/.codex


### PR DESCRIPTION
## Summary
- Remove redundant `uv` curl in `install_python_tools.sh` — uv is already installed via Brewfile, the curl was hitting a 301 and erroring
- Remove duplicate npm installs in `install_apps.sh` — Claude Code and Mermaid CLI are already handled by Brewfile `npm` entries
- Skip interactive Codex auth in `setup_codex.sh` — the browser login blocked bootstrap; user can run `codex login` manually after setup

## Test plan
- [ ] Run `bash scripts/bootstrap.sh` and confirm it completes without hanging or erroring on these three steps