### PR TITLE
Add ~/.local/bin to fish PATH

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -25,3 +25,4 @@ function __auto_dotenv --on-variable PWD
         dotenv .env
     end
 end
+fish_add_path $HOME/.local/bin


### PR DESCRIPTION
## Summary
- Adds `fish_add_path $HOME/.local/bin` to `config.fish` so tools installed to `~/.local/bin` (e.g. via `uv tool install`, `pipx`) are available in the shell

## Test plan
- [ ] Open a new fish shell and confirm `echo $PATH` includes `~/.local/bin`