### PR TITLE
Remove PyCharm and Cursor, clean up dock layout

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -38,9 +38,7 @@ brew "tree"         # directory tree display
 brew "zoxide"       # cd replacement
 
 # Development Applications
-cask "cursor"
 cask "fork"
-cask "pycharm"
 cask "visual-studio-code"
 
 # Productivity & Utilities

--- a/scripts/setup_dock.sh
+++ b/scripts/setup_dock.sh
@@ -28,20 +28,9 @@ dockutil --add '' --type spacer --section apps --no-restart
 # -----------------------
 # 👨‍💻 Dev & Ops
 # -----------------------
-dockutil --add "/Applications/Cursor.app" --no-restart
 dockutil --add "/Applications/Fork.app" --no-restart
 dockutil --add "/Applications/Ghostty.app" --no-restart
-dockutil --add "/Applications/PyCharm.app" --no-restart
 dockutil --add "/Applications/Visual Studio Code.app" --no-restart
-dockutil --add '' --type spacer --section apps --no-restart
-
-# -----------------------
-# 🤝 Communication
-# -----------------------
-# dockutil --add "/Applications/Microsoft Outlook.app" --no-restart
-# dockutil --add "/Applications/Microsoft Teams.app" --no-restart
-dockutil --add "/System/Applications/Messages.app" --no-restart
-dockutil --add "/System/Applications/FaceTime.app" --no-restart
 dockutil --add '' --type spacer --section apps --no-restart
 
 # -----------------------
@@ -60,6 +49,7 @@ dockutil --add '' --type spacer --section apps --no-restart
 # dockutil --add "/System/Applications/Calendar.app" --no-restart
 # dockutil --add "/System/Applications/Reminders.app" --no-restart
 dockutil --add "/System/Applications/Music.app" --no-restart
+dockutil --add "/System/Applications/Messages.app" --no-restart
 dockutil --add "/System/Applications/System Settings.app" --no-restart
 # dockutil --add "/System/Applications/Siri.app" --no-restart
 # dockutil --add "/System/Applications/Home.app" --no-restart


### PR DESCRIPTION
Closes #95

## Summary
- Remove `pycharm` and `cursor` from Brewfile — VS Code only now
- Remove FaceTime from dock
- Move Messages to between Music and System Settings
- Remove Cursor and PyCharm from dock